### PR TITLE
Fix summary function arguments bug

### DIFF
--- a/verticall/summary.py
+++ b/verticall/summary.py
@@ -31,7 +31,7 @@ def summary(args):
     summarised_data = summarise_data(data, contig_lengths, args.all)
     if args.plot:
         plot = summary_plot(sample_name, summarised_data, contig_lengths, args.vertical_colour,
-                            args.horizontal_colour, args.ambiguous_colour)
+                            args.horizontal_colour, args.unaligned_colour)
         plt.show()
     else:
         print('contig', 'position', 'vertical', 'horizontal', 'unaligned')
@@ -118,7 +118,7 @@ def summarise_data(data, contig_lengths, output_all):
 
 
 def summary_plot(sample_name, summarised_data, contig_lengths, vertical_colour, horizontal_colour,
-                 ambiguous_colour):
+                 unaligned_colour):
     title = f'{sample_name} painting summary'
 
     boundaries = [0]
@@ -157,7 +157,7 @@ def summary_plot(sample_name, summarised_data, contig_lengths, vertical_colour, 
         offset += length
 
     g += scale_fill_manual({'vertical': vertical_colour, 'horizontal': horizontal_colour,
-                            'unaligned': ambiguous_colour}, guide=False)
+                            'unaligned': unaligned_colour}, guide=False)
 
     for b in boundaries:
         g += geom_vline(xintercept=b, colour='#000000', size=0.5)


### PR DESCRIPTION
Hi Ryan,
Amazing tool as always!
I came across a problem with the `summary` function when trying to draw a plot with the following command:
```
python3 ../Verticall/verticall-runner.py summary -i verticall.tsv -a assembly_verticall_symlinks/SRR5973343.fasta --plot
```
Which throws this error:
```
Traceback (most recent call last):
  File "/Users/tom/Bioinformatics/CG29/../Verticall/verticall-runner.py", line 22, in <module>
    main()
  File "/Users/tom/Bioinformatics/Verticall/verticall/__main__.py", line 49, in main
    summary(args)
  File "/Users/tom/Bioinformatics/Verticall/verticall/summary.py", line 34, in summary
    args.horizontal_colour, args.ambiguous_colour)
AttributeError: 'Namespace' object has no attribute 'ambiguous_colour'
```
This change fixes it for me.